### PR TITLE
Fixed sample code to register for photo services

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,15 @@ Before even creating a new instance of DZNPhotoPickerController, it is recommend
 ```
 + (void)initialize
 {
-    [DZNPhotoPickerController registerForServiceType:DZNPhotoPickerControllerService500px
-                                    withConsumerKey:YOUR_500px_KEY
-                                  andConsumerSecret:YOUR_500px_SECRET
-                                  subscription:DZNPhotoPickerControllerSubscriptionFree];
+    [DZNPhotoPickerController registerService:DZNPhotoPickerControllerService500px
+                                  consumerKey:YOUR_500px_KEY
+                               consumerSecret:YOUR_500px_SECRET
+                                 subscription:DZNPhotoPickerControllerSubscriptionFree];
     
-    [DZNPhotoPickerController registerForServiceType:DZNPhotoPickerControllerServiceFlickr
-                                    withConsumerKey:YOUR_Flickr_KEY
-                                  andConsumerSecret:YOUR_Flickr_SECRET
-                                  subscription:DZNPhotoPickerControllerSubscriptionFree];
+    [DZNPhotoPickerController registerService:DZNPhotoPickerControllerServiceFlickr
+                                  consumerKey:YOUR_Flickr_KEY
+                               consumerSecret:YOUR_Flickr_SECRET
+                                 subscription:DZNPhotoPickerControllerSubscriptionFree];
 }
 ```
 


### PR DESCRIPTION
README had old sample code for registering for services that causes an error when trying to compile; updated it to match the current API.
