### PR TITLE
AFNetworking 2.2 support added

### DIFF
--- a/DZNPhotoPickerController.podspec
+++ b/DZNPhotoPickerController.podspec
@@ -1,7 +1,6 @@
-
 Pod::Spec.new do |s|
   s.name         	= "DZNPhotoPickerController"
-  s.version      	= "1.3.2"
+  s.version      	= "1.4.0"
   s.summary      	= "A photo search/picker for iOS using popular providers like 500px, Flickr, Intagram, Google Images, etc."
   s.description  	= "This framework tries to mimic as close as possible the native UIImagePickerController API for iOS7, in terms of features, appearance and behaviour."
   s.homepage   		= "https://github.com/dzenbot/DZNPhotoPickerController"
@@ -9,11 +8,11 @@ Pod::Spec.new do |s|
   s.license     	= { :type => 'MIT', :file => 'LICENSE' }
   s.author       	= { "Ignacio Romero Z." => "iromero@dzen.cl" }
   s.platform    	= :ios, '7.0'
-  s.source       	= { :git => "https://github.com/dzenbot/UIPhotoPickerController.git", :tag => "v1.3.2" }
+  s.source       	= { :git => "https://github.com/dzenbot/UIPhotoPickerController.git", :tag => "v1.4.0" }
   s.source_files  = 'Classes', 'Source/Classes/**/*.{h,m}'
   s.resources     = 'Resources', 'Source/Resources/**/*.*'
   s.requires_arc 	= true
   s.prefix_header_contents = '#import <MobileCoreServices/MobileCoreServices.h>', '#import <SystemConfiguration/SystemConfiguration.h>'
-  s.dependency 'AFNetworking', '~> 1.3.3'
+  s.dependency 'AFNetworking', '~> 2.2'
   s.dependency 'SDWebImage', '~> 3.5.4'
 end

--- a/Examples/Sample/Podfile
+++ b/Examples/Sample/Podfile
@@ -1,4 +1,4 @@
 platform :ios, '7.0'
 
-pod 'AFNetworking', '~> 1.3.3'
+pod 'AFNetworking', '~> 2.2'
 pod 'SDWebImage', '~> 3.5.4'

--- a/Examples/Sample/Podfile.lock
+++ b/Examples/Sample/Podfile.lock
@@ -1,15 +1,33 @@
 PODS:
-  - AFNetworking (1.3.3)
+  - AFNetworking (2.2.3):
+    - AFNetworking/NSURLConnection
+    - AFNetworking/NSURLSession
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+    - AFNetworking/UIKit
+  - AFNetworking/NSURLConnection (2.2.3):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/NSURLSession (2.2.3):
+    - AFNetworking/NSURLConnection
+  - AFNetworking/Reachability (2.2.3)
+  - AFNetworking/Security (2.2.3)
+  - AFNetworking/Serialization (2.2.3)
+  - AFNetworking/UIKit (2.2.3):
+    - AFNetworking/NSURLConnection
+    - AFNetworking/NSURLSession
   - SDWebImage (3.5.4):
     - SDWebImage/Core
   - SDWebImage/Core (3.5.4)
 
 DEPENDENCIES:
-  - AFNetworking (~> 1.3.3)
+  - AFNetworking (~> 2.2)
   - SDWebImage (~> 3.5.4)
 
 SPEC CHECKSUMS:
-  AFNetworking: 61fdd49e2ffe6380378df37b3b6e70630bb9dd66
+  AFNetworking: ae513199cca79e9d7af2708ccabe2ed075550c42
   SDWebImage: 1a62010700adbba823b621fc217906739dbf6aa5
 
-COCOAPODS: 0.29.0
+COCOAPODS: 0.32.1

--- a/Source/Classes/ServicesAPI/DZNPhotoServiceClient.h
+++ b/Source/Classes/ServicesAPI/DZNPhotoServiceClient.h
@@ -8,7 +8,7 @@
 //  Licence: MIT-Licence
 //
 
-#import "AFHTTPClient.h"
+#import <AFNetworking.h>
 #import "DZNPhotoPickerControllerConstants.h"
 #import "DZNPhotoServiceClientProtocol.h"
 
@@ -19,7 +19,7 @@ UIKIT_EXTERN NSString *const DZNPhotoServiceClientSubscription;
 /**
  * The HTTP service client used to interact with multiple RESTful APIs for photo search services.
  */
-@interface DZNPhotoServiceClient : AFHTTPClient <DZNPhotoServiceClientProtocol>
+@interface DZNPhotoServiceClient : AFHTTPRequestOperationManager <DZNPhotoServiceClientProtocol>
 
 /**
  * Initializes a new HTTP service client.

--- a/Source/Classes/ServicesAPI/DZNPhotoServiceClient.m
+++ b/Source/Classes/ServicesAPI/DZNPhotoServiceClient.m
@@ -28,7 +28,9 @@
 {
     self = [super initWithBaseURL:baseURLForService(service)];
     if (self) {
-        self.parameterEncoding = AFJSONParameterEncoding;
+        self.requestSerializer = [AFJSONRequestSerializer serializer];
+        self.responseSerializer = [AFHTTPResponseSerializer serializer];
+        
         _service = service;
         _subscription = subscription;
     }
@@ -179,8 +181,8 @@
         NSString *keyword = [params objectForKey:keyForSearchTerm(_service)];
         path = [path stringByReplacingOccurrencesOfString:@"%@" withString:keyword];
     }
-    
-    [self getPath:path parameters:params success:^(AFHTTPRequestOperation *operation, id response) {
+
+    [self GET:path parameters:params success:^(AFHTTPRequestOperation *operation, id response) {
         
         NSData *data = [self processData:response];
         NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableLeaves | NSJSONReadingAllowFragments error:nil];
@@ -200,7 +202,7 @@
     if (_loadingPath) {
         
         if (_service == DZNPhotoPickerControllerServiceFlickr) _loadingPath = @"";
-        [self cancelAllHTTPOperationsWithMethod:@"GET" path:_loadingPath];
+        [self.operationQueue cancelAllOperations];
         
         _loadingPath = nil;
     }


### PR DESCRIPTION
AFNetworking 2 is already out for awhile now, and it's impossible to use `DZNPhotoPickerController` in apps that utilize `AFNetworking` 2, as it creates a conflict when installing the cocoapods.
