### PR TITLE
support iOS 6 with layout imperfections

### DIFF
--- a/DZNPhotoPickerController.podspec
+++ b/DZNPhotoPickerController.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.default_subspec = 'Core'
   s.resources       = 'Resources', 'Source/Resources/**/*.*'
   s.requires_arc 	  = true
-  s.platform        = :ios, '7.0'
+  s.platform        = :ios, '6.0'
 
   s.subspec 'Core' do |ss|
     ss.source_files = 'Source/Classes/Core/*.{h,m}'

--- a/Source/Classes/Core/DZNPhotoDisplayViewController.m
+++ b/Source/Classes/Core/DZNPhotoDisplayViewController.m
@@ -22,6 +22,8 @@
 #import "UIScrollView+EmptyDataSet.h"
 #import "MBProgressHUD.h"
 
+#define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
+
 static NSString *kDZNPhotoCellViewIdentifier = @"kDZNPhotoCellViewIdentifier";
 static NSString *kDZNPhotoFooterViewIdentifier = @"kDZNPhotoFooterViewIdentifier";
 static NSString *kDZNTagCellViewIdentifier = @"kDZNTagCellViewIdentifier";
@@ -86,9 +88,11 @@ static CGFloat kDZNPhotoDisplayMinimumBarHeight = 44.0;
     
     self.view.backgroundColor = [UIColor whiteColor];
     
-    self.edgesForExtendedLayout = UIRectEdgeAll;
-    self.extendedLayoutIncludesOpaqueBars = YES;
-    self.automaticallyAdjustsScrollViewInsets = YES;
+    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"7.0")) {
+        self.edgesForExtendedLayout = UIRectEdgeAll;
+        self.extendedLayoutIncludesOpaqueBars = YES;
+        self.automaticallyAdjustsScrollViewInsets = YES;
+    }
     
     self.collectionView.backgroundView = [UIView new];
     self.collectionView.backgroundView.backgroundColor = [UIColor whiteColor];
@@ -164,7 +168,9 @@ Returns the custom collection view layout.
         _searchController.searchResultsTableView.tableFooterView = [UIView new];
         _searchController.searchResultsTableView.backgroundView = [UIView new];
         _searchController.searchResultsTableView.backgroundView.backgroundColor = [UIColor whiteColor];
-        _searchController.searchResultsTableView.keyboardDismissMode = UIScrollViewKeyboardDismissModeNone;
+        if ([_searchController.searchResultsTableView respondsToSelector:@selector(setKeyboardDismissMode:)]) {
+            _searchController.searchResultsTableView.keyboardDismissMode = UIScrollViewKeyboardDismissModeNone;
+        }
         _searchController.searchResultsDataSource = self;
         _searchController.searchResultsDelegate = self;
         _searchController.delegate = self;
@@ -182,11 +188,13 @@ Returns the custom collection view layout.
     if (!_searchBar)
     {
         _searchBar = [[UISearchBar alloc] initWithFrame:[self searchBarFrame]];
+        if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"7.0")) {
+            _searchBar.searchBarStyle = UISearchBarStyleDefault;
+            _searchBar.barTintColor = [UIColor colorWithRed:202.0/255.0 green:202.0/255.0 blue:207.0/255.0 alpha:1.0];
+        }
         _searchBar.placeholder = NSLocalizedString(@"Search", nil);
         _searchBar.barStyle = UIBarStyleDefault;
-        _searchBar.searchBarStyle = UISearchBarStyleDefault;
         _searchBar.backgroundColor = [UIColor whiteColor];
-        _searchBar.barTintColor = [UIColor colorWithRed:202.0/255.0 green:202.0/255.0 blue:207.0/255.0 alpha:1.0];
         _searchBar.tintColor = self.view.window.tintColor;
         _searchBar.keyboardType = UIKeyboardAppearanceDark;
         _searchBar.text = self.navigationController.initialSearchTerm;

--- a/Source/Classes/Core/DZNPhotoPickerController.m
+++ b/Source/Classes/Core/DZNPhotoPickerController.m
@@ -72,7 +72,9 @@ static DZNPhotoPickerControllerCancellationBlock _cancellationBlock;
     [super loadView];
     
     self.view.backgroundColor = [UIColor whiteColor];
-    self.edgesForExtendedLayout = UIRectEdgeTop;
+    if ([self respondsToSelector:@selector(setEdgesForExtendedLayout:)]) {
+        self.edgesForExtendedLayout = UIRectEdgeTop;
+    }
 }
 
 - (void)viewDidLoad

--- a/Source/Classes/Editor/DZNPhotoEditorViewController.m
+++ b/Source/Classes/Editor/DZNPhotoEditorViewController.m
@@ -89,14 +89,18 @@ typedef NS_ENUM(NSInteger, DZNPhotoAspect) {
 
 - (void)commonInit
 {
-    self.automaticallyAdjustsScrollViewInsets = NO;
+    if ([self respondsToSelector:@selector(setAutomaticallyAdjustsScrollViewInsets:)]) {
+        self.automaticallyAdjustsScrollViewInsets = NO;
+    }
     self.view.backgroundColor = [UIColor blackColor];
     
     if (DZN_IS_IPAD) {
         self.title = NSLocalizedString(@"Edit Photo", nil);
     }
     else {
-        self.edgesForExtendedLayout = UIRectEdgeNone;
+        if ([self respondsToSelector:@selector(setEdgesForExtendedLayout:)]) {
+            self.edgesForExtendedLayout = UIRectEdgeNone;
+        }
     }
 }
 
@@ -226,7 +230,9 @@ typedef NS_ENUM(NSInteger, DZNPhotoAspect) {
     {
         _bottomView = [DZNPhotoEditorContainerView new];
         _bottomView.translatesAutoresizingMaskIntoConstraints = NO;
-        _bottomView.tintColor = [UIColor whiteColor];
+        if ([_bottomView respondsToSelector:@selector(setTintColor:)]) {
+            _bottomView.tintColor = [UIColor whiteColor];
+        }
         _bottomView.userInteractionEnabled = YES;
         
         _leftButton = [self buttonWithTitle:NSLocalizedString(@"Cancel", nil)];


### PR DESCRIPTION
Add initial support to iOS 6.
DZNPhotoEditorViewController working perfectly, besides ugly Cancel and Choose buttons.
DZNPhotoPickerController needs some heavier layout polishing, but it's perfectly functional.
Tested on an iPod 4 with iOS 6.1.6 compiling with Xcode 6.1.1.