### PR TITLE
Fix picker never being deallocated due to retain cycle.

### DIFF
--- a/Source/Classes/Core/DZNPhotoPickerController.m
+++ b/Source/Classes/Core/DZNPhotoPickerController.m
@@ -75,21 +75,22 @@ static DZNPhotoPickerControllerCancellationBlock _cancellationBlock;
     self.edgesForExtendedLayout = UIRectEdgeTop;
 }
 
-- (void)viewDidLoad
-{
-    [super viewDidLoad];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didFinishPickingPhoto:) name:DZNPhotoPickerDidFinishPickingNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didFailPickingPhoto:) name:DZNPhotoPickerDidFailPickingNotification object:nil];
-}
-
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
 
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didFinishPickingPhoto:) name:DZNPhotoPickerDidFinishPickingNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didFailPickingPhoto:) name:DZNPhotoPickerDidFailPickingNotification object:nil];
+    
     if (!self.isEditModeEnabled) {
         [self showPhotoDisplayController];
     }
+}
+
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+    
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 
@@ -232,8 +233,6 @@ static DZNPhotoPickerControllerCancellationBlock _cancellationBlock;
 
 - (void)dealloc
 {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-    
     _initialSearchTerm = nil;
     _finalizationBlock = nil;
     _cancellationBlock = nil;


### PR DESCRIPTION
NSNotificationCenter addObserver retains the observer and for that reason removing the observer on dealloc creates a retain cycle.
In my project this was causing a crash because an unallocated object was being called by a DZNPhotoPickerController that should be already deallocated. I thought it was worth it sharing.

Best regards