### PR TITLE
Add Giphy to Image Services

### DIFF
--- a/Examples/PhotoPicker/PhotoPicker/Private.h
+++ b/Examples/PhotoPicker/PhotoPicker/Private.h
@@ -30,3 +30,5 @@
 
 #define kGettyImagesConsumerKey         @"tt4fyd5487kgsjtfkf46v3d4"
 #define kGettyImagesConsumerSecret      @"jQhYJvW8HncyMd9UaEbc8vAYKuDyK2UxtmPHAmSnRhpy5" //1000 request per day (free account)
+
+#define kGiphyConsumerKey               @"dc6zaTOxFJmzC"

--- a/Examples/PhotoPicker/PhotoPicker/RootViewController.m
+++ b/Examples/PhotoPicker/PhotoPicker/RootViewController.m
@@ -47,6 +47,10 @@
     [DZNPhotoPickerController registerFreeService:DZNPhotoPickerControllerServiceGettyImages
                                       consumerKey:kGettyImagesConsumerKey
                                    consumerSecret:kGettyImagesConsumerSecret];
+
+    [DZNPhotoPickerController registerFreeService:DZNPhotoPickerControllerServiceGiphy
+                                      consumerKey:kGiphyConsumerKey
+                                   consumerSecret:nil];
 }
 
 - (void)viewDidLoad
@@ -100,7 +104,7 @@
 - (void)presentPhotoSearch:(id)sender
 {
     DZNPhotoPickerController *picker = [DZNPhotoPickerController new];
-    picker.supportedServices = DZNPhotoPickerControllerService500px | DZNPhotoPickerControllerServiceFlickr | DZNPhotoPickerControllerServiceGoogleImages;
+    picker.supportedServices =  DZNPhotoPickerControllerService500px | DZNPhotoPickerControllerServiceFlickr | DZNPhotoPickerControllerServiceGoogleImages | DZNPhotoPickerControllerServiceGiphy;
     picker.allowsEditing = NO;
     picker.cropMode = DZNPhotoEditorViewControllerCropModeSquare;
     picker.initialSearchTerm = @"California";

--- a/Source/Classes/Core/DZNPhotoPickerControllerConstants.h
+++ b/Source/Classes/Core/DZNPhotoPickerControllerConstants.h
@@ -25,6 +25,7 @@ typedef NS_OPTIONS(NSUInteger, DZNPhotoPickerControllerServices) {
     DZNPhotoPickerControllerServiceGoogleImages = (1 << 3),                 // Google Images                https://developers.google.com/custom-search/
     DZNPhotoPickerControllerServiceBingImages = (1 << 4),                   // Bing Images                  http://datamarket.azure.com/dataset/bing/search/
     DZNPhotoPickerControllerServiceGettyImages = (1 << 5),                  // Getty Images                 http://api.gettyimages.com/
+    DZNPhotoPickerControllerServiceGiphy = (1 << 6),                        // Giphy                        http://api.giphy.com/v1/gifs/search/
 };
 
 /**

--- a/Source/Classes/Core/DZNPhotoPickerControllerConstants.m
+++ b/Source/Classes/Core/DZNPhotoPickerControllerConstants.m
@@ -27,6 +27,7 @@ NSString *NSStringFromService(DZNPhotoPickerControllerServices service)
         case DZNPhotoPickerControllerServiceGoogleImages:   return @"Google";
         case DZNPhotoPickerControllerServiceBingImages:     return @"Bing";
         case DZNPhotoPickerControllerServiceGettyImages:    return @"Getty Images";
+        case DZNPhotoPickerControllerServiceGiphy:          return @"Giphy";
         default:                                            return nil;
     }
 }
@@ -39,6 +40,7 @@ DZNPhotoPickerControllerServices DZNPhotoServiceFromName(NSString *name)
     if ([name isEqualToString:NSStringFromService(DZNPhotoPickerControllerServiceGoogleImages)])    return DZNPhotoPickerControllerServiceGoogleImages;
     if ([name isEqualToString:NSStringFromService(DZNPhotoPickerControllerServiceBingImages)])      return DZNPhotoPickerControllerServiceBingImages;
     if ([name isEqualToString:NSStringFromService(DZNPhotoPickerControllerServiceGettyImages)])     return DZNPhotoPickerControllerServiceGettyImages;
+    if ([name isEqualToString:NSStringFromService(DZNPhotoPickerControllerServiceGiphy)])           return DZNPhotoPickerControllerServiceGiphy;
     return -1;
 }
 
@@ -61,6 +63,9 @@ DZNPhotoPickerControllerServices DZNFirstPhotoServiceFromPhotoServices(DZNPhotoP
     }
     if ((services & DZNPhotoPickerControllerServiceGettyImages) > 0) {
         return DZNPhotoPickerControllerServiceGettyImages;
+    }
+    if ((services & DZNPhotoPickerControllerServiceGiphy) > 0) {
+        return DZNPhotoPickerControllerServiceGiphy;
     }
     return -1;
 }
@@ -87,6 +92,9 @@ NSArray *NSArrayFromServices(DZNPhotoPickerControllerServices services)
     }
     if ((services & DZNPhotoPickerControllerServiceGettyImages) > 0) {
         [titles addObject:NSStringFromService(DZNPhotoPickerControllerServiceGettyImages)];
+    }
+    if ((services & DZNPhotoPickerControllerServiceGiphy) > 0) {
+        [titles addObject:NSStringFromService(DZNPhotoPickerControllerServiceGiphy)];
     }
     return [NSArray arrayWithArray:titles];
 }

--- a/Source/Classes/Services/DZNPhotoMetadata.m
+++ b/Source/Classes/Services/DZNPhotoMetadata.m
@@ -120,6 +120,23 @@
                 _contentType = [NSString stringWithFormat:@"image/%@",[_sourceURL pathExtension]];
             }
         }
+        else if ((service & DZNPhotoPickerControllerServiceGiphy) > 0)
+        {
+            _Id = [object objectForKey:@"id"];
+
+            NSString *sourceUrl = [object valueForKeyPath:@"images.original.url"];
+            _sourceURL = [NSURL URLWithString:[sourceUrl stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+
+            NSString *thumbUrl = [object valueForKeyPath:@"images.fixed_width_downsampled.url"];
+            _thumbURL = [NSURL URLWithString:[thumbUrl stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+
+            _width = [object valueForKeyPath:@"images.original.width"];
+            _height = [object valueForKeyPath:@"images.origninal.height"];
+
+            if (_sourceURL) {
+                _contentType = [NSString stringWithFormat:@"image/%@",[_sourceURL pathExtension]];
+            }
+        }
     }
     return self;
 }

--- a/Source/Classes/Services/DZNPhotoServiceClient.m
+++ b/Source/Classes/Services/DZNPhotoServiceClient.m
@@ -195,6 +195,13 @@
         [params setObject:@"photography" forKey:@"graphical_styles"];
         [params setObject:@"true" forKey:@"exclude_nudity"];
     }
+    else if (self.service == DZNPhotoPickerControllerServiceGiphy)
+    {
+        [params setObject:@"pg" forKey:@"rating"];
+        if (page > 1) {
+            [params setObject:@((page-1)*resultPerPage) forKey:@"offset"];
+        }
+    }
     
     return params;
 }
@@ -296,7 +303,7 @@
     else if (self.service == DZNPhotoPickerControllerServiceFlickr) {
         path = @"";
     }
-        
+    
     [self GET:path parameters:params
       success:^(AFHTTPRequestOperation *operation, id response) {
           

--- a/Source/Classes/Services/DZNPhotoServiceConstants.m
+++ b/Source/Classes/Services/DZNPhotoServiceConstants.m
@@ -34,6 +34,7 @@ NSURL *baseURLForService(DZNPhotoPickerControllerServices service)
         case DZNPhotoPickerControllerServiceGoogleImages:       return [NSURL URLWithString:@"https://www.googleapis.com/customsearch/v1/"];
         case DZNPhotoPickerControllerServiceBingImages:         return [NSURL URLWithString:@"https://api.datamarket.azure.com/"];
         case DZNPhotoPickerControllerServiceGettyImages:        return [NSURL URLWithString:@"https://connect.gettyimages.com/"];
+        case DZNPhotoPickerControllerServiceGiphy:              return [NSURL URLWithString:@"https://api.giphy.com/"];
         default:                                                return nil;
     }
 }
@@ -66,6 +67,7 @@ NSString *photosResourceKeyPathForService(DZNPhotoPickerControllerServices servi
         case DZNPhotoPickerControllerServiceGoogleImages:       return @"items";
         case DZNPhotoPickerControllerServiceBingImages:         return @"d.results";
         case DZNPhotoPickerControllerServiceGettyImages:        return @"images";
+        case DZNPhotoPickerControllerServiceGiphy:              return @"data";
         default:                                                return nil;
     }
 }
@@ -79,6 +81,7 @@ NSString *photoSearchUrlPathForService(DZNPhotoPickerControllerServices service)
         case DZNPhotoPickerControllerServiceGoogleImages:       return @"";
         case DZNPhotoPickerControllerServiceBingImages:         return @"Bing/Search/Image?$format=json";
         case DZNPhotoPickerControllerServiceGettyImages:        return @"v3/search/images/creative";
+        case DZNPhotoPickerControllerServiceGiphy:              return @"v1/gifs/search";
         default:                                                return nil;
     }
 }
@@ -99,6 +102,7 @@ NSString *keyForAPIConsumerKey(DZNPhotoPickerControllerServices service)
         case DZNPhotoPickerControllerServiceInstagram:          return @"client_id";
         case DZNPhotoPickerControllerServiceGoogleImages:       return @"key";
         case DZNPhotoPickerControllerServiceGettyImages:        return @"Api-Key";
+        case DZNPhotoPickerControllerServiceGiphy:              return @"api_key";
         default:                                                return nil;
     }
 }
@@ -121,6 +125,7 @@ NSString *keyForSearchTerm(DZNPhotoPickerControllerServices service)
         case DZNPhotoPickerControllerServiceGoogleImages:       return @"q";
         case DZNPhotoPickerControllerServiceBingImages:         return @"Query";
         case DZNPhotoPickerControllerServiceGettyImages:        return @"phrase";
+        case DZNPhotoPickerControllerServiceGiphy:              return @"q";
         default:                                                return nil;
     }
 }
@@ -143,6 +148,7 @@ NSString *keyForSearchResultPerPage(DZNPhotoPickerControllerServices service)
         case DZNPhotoPickerControllerServiceFlickr:             return @"per_page";
         case DZNPhotoPickerControllerServiceGoogleImages:       return @"num";
         case DZNPhotoPickerControllerServiceGettyImages:        return @"page_size";
+        case DZNPhotoPickerControllerServiceGiphy:              return @"limit";
         default:                                                return nil;
     }
 }


### PR DESCRIPTION
Add api.giphy.com as a source for selectable images.  The code uses the downsampled and smaller-sized images for the preview, but will return the fill size image as a selected result.  The included API key is their beta-test sample and shouldn't be used in production, like the others.