### PR TITLE
Master

### DIFF
--- a/Source/Classes/Core/DZNPhotoDisplayViewController.m
+++ b/Source/Classes/Core/DZNPhotoDisplayViewController.m
@@ -181,7 +181,7 @@ static NSUInteger kDZNPhotoDisplayMinimumColumnCount = 4.0;
         UISearchBar *searchBar = _searchController.searchBar;
         searchBar.placeholder = NSLocalizedString(@"Search", nil);
         searchBar.text = self.navigationController.initialSearchTerm;
-        searchBar.scopeButtonTitles = self.segmentedControlTitles;
+        searchBar.scopeButtonTitles = [self segmentedControlTitles].count > 1 ? [self segmentedControlTitles] : nil;
         searchBar.searchBarStyle = UISearchBarStyleProminent;
         searchBar.barStyle = UIBarStyleDefault;
         searchBar.selectedScopeButtonIndex = 0;
@@ -232,14 +232,6 @@ static NSUInteger kDZNPhotoDisplayMinimumColumnCount = 4.0;
         _activityIndicator.color = [UIColor grayColor];
     }
     return _activityIndicator;
-}
-
-- (NSArray *)segmentedControlTitles
-{
-    if (_segmentedControlTitles.count > 1) {
-        return _segmentedControlTitles;
-    }
-    return nil;
 }
 
 /* Returns the appropriate cell view's size. */
@@ -900,7 +892,10 @@ static NSUInteger kDZNPhotoDisplayMinimumColumnCount = 4.0;
         text = localizedDescription;
     }
     else if (!self.loading) {
-        text = NSLocalizedString(@"Make sure that all words are\nspelled correctly.", nil);
+        if (self.navigationController.initialSearchTerm)
+            text = NSLocalizedString(@"Make sure that all words are\nspelled correctly.", nil);
+        else
+            text = nil;
     }
     
     if (text) {

--- a/Source/Classes/Core/DZNPhotoPickerController.m
+++ b/Source/Classes/Core/DZNPhotoPickerController.m
@@ -34,7 +34,7 @@ static DZNPhotoPickerControllerCancellationBlock _cancellationBlock;
         self.enablePhotoDownload = YES;
         self.allowAutoCompletedSearch = YES;
         
-        self.supportedServices = DZNPhotoPickerControllerService500px | DZNPhotoPickerControllerServiceFlickr;
+        self.supportedServices = DZNPhotoPickerControllerServiceGoogleImages | DZNPhotoPickerControllerServiceFlickr;
         self.supportedLicenses = DZNPhotoPickerControllerCCLicenseBY_ALL;
         self.cropMode = DZNPhotoEditorViewControllerCropModeSquare;
     }

--- a/Source/Classes/Services/DZNPhotoServiceClient.m
+++ b/Source/Classes/Services/DZNPhotoServiceClient.m
@@ -150,7 +150,8 @@
         [params setObject:[self consumerSecret] forKey:keyForAPIConsumerSecret(self.service)];
         [params setObject:@"image" forKey:@"searchType"];
         [params setObject:@"medium" forKey:@"safe"];
-        if (page > 1) [params setObject:@((page - 1) * resultPerPage + 1) forKey:@"start"];
+        [params setObject:@(10) forKey:@"num"];
+        [params setObject:@(page ? page * resultPerPage + 1 : 1) forKey:@"start"];
     }
     else if (self.service == DZNPhotoPickerControllerServiceBingImages)
     {
@@ -158,6 +159,7 @@
         
         //Default to size medium. Size Large causes some buggy behavior with download times.
         [params setObject:@"'Size:Medium'" forKey:@"ImageFilters"];
+        [params setObject:@"Image" forKey:@"Source"];
     }
     else if (self.service == DZNPhotoPickerControllerServiceGiphy)
     {
@@ -236,7 +238,29 @@
     NSString *path = photoSearchUrlPathForService(self.service);
     
     NSDictionary *params = [self photosParamsWithKeyword:keyword page:page resultPerPage:resultPerPage];
-    [self getObject:[DZNPhotoMetadata class] path:path params:params completion:completion];
+    __block NSMutableArray * aggregate = [NSMutableArray arrayWithCapacity:resultPerPage];
+    __block NSInteger currentPage = [[params objectForKey:keyForSearchPage(self.service)] integerValue];
+    NSLog(@"starting with currentPage %ul", currentPage);
+    __block DZNHTTPRequestCompletion recursive = ^(NSArray *list, NSError *error) {
+        if (error)
+            completion(nil, error);
+
+        [aggregate addObjectsFromArray:list];
+        currentPage = currentPage + list.count;
+        if ((aggregate.count < resultPerPage) && list.count) {
+            NSLog(@"asking for more at %ul after receiving %ul", currentPage, list.count);
+            [params setValue:@(currentPage) forKey:keyForSearchPage(self.service)];
+            [params setValue:MIN(@(resultPerPage - aggregate.count),[params objectForKey:keyForSearchResultPerPage(self.service)])  forKey:keyForSearchResultPerPage(self.service)];
+            [self getObject:[DZNPhotoMetadata class] path:path params:params completion:recursive];
+        } else {
+            NSLog(@"received all items %ul",aggregate.count);
+            completion(aggregate, nil);
+        }
+    };
+    
+    [self getObject:[DZNPhotoMetadata class] path:path params:params completion:recursive];
+
+    
 }
 
 - (void)getObject:(Class)class path:(NSString *)path params:(NSDictionary *)params completion:(DZNHTTPRequestCompletion)completion

--- a/Source/Classes/Services/DZNPhotoServiceConstants.m
+++ b/Source/Classes/Services/DZNPhotoServiceConstants.m
@@ -143,6 +143,7 @@ NSString *keyForSearchResultPerPage(DZNPhotoPickerControllerServices service)
 NSString *keyForSearchPage(DZNPhotoPickerControllerServices service)
 {
     switch (service) {
+        case DZNPhotoPickerControllerServiceGoogleImages:       return @"start";
         default:                                                return @"page";
     }
 }


### PR DESCRIPTION
These changes address issues with the google service. Google only allows 10 photos per search. This code will recursively fetch more results until the total number needed to fulfill the search
page are returned. Google also returns an error after 100 results are fetched so that is the hard limit on the number of images per query. There are also a few other fixes for UI includes the searchbar when there is only one title. This code could be cleaned up a bit by having a constant that defines the maximum number of results for a given service. Currently this is hardcoded in the params for the service. Theoretically the code should work for any “underperforming” service. 