### PR TITLE
Fix 400 error on Bing provider and enable paging using $top and $skip parameters

### DIFF
--- a/Source/Classes/Services/DZNPhotoServiceClient.m
+++ b/Source/Classes/Services/DZNPhotoServiceClient.m
@@ -158,6 +158,9 @@
         
         //Default to size medium. Size Large causes some buggy behavior with download times.
         [params setObject:@"'Size:Medium'" forKey:@"ImageFilters"];
+        
+        [params setObject:@(resultPerPage) forKey:@"$top"];
+        [params setObject:@(page * resultPerPage) forKey:@"$skip"];
     }
     else if (self.service == DZNPhotoPickerControllerServiceGiphy)
     {

--- a/Source/Classes/Services/DZNPhotoServiceConstants.m
+++ b/Source/Classes/Services/DZNPhotoServiceConstants.m
@@ -143,6 +143,7 @@ NSString *keyForSearchResultPerPage(DZNPhotoPickerControllerServices service)
 NSString *keyForSearchPage(DZNPhotoPickerControllerServices service)
 {
     switch (service) {
+        case DZNPhotoPickerControllerServiceBingImages:         return nil;
         default:                                                return @"page";
     }
 }


### PR DESCRIPTION
Bing was not working out of the box after updating from 1.x so I went ahead and fixed it in 2.x. 