### PR TITLE
Send search term for chosen image with image metadata

### DIFF
--- a/Source/Classes/Core/DZNPhotoDisplayViewController.m
+++ b/Source/Classes/Core/DZNPhotoDisplayViewController.m
@@ -432,7 +432,14 @@ static NSUInteger kDZNPhotoDisplayMinimumColumnCount = 4.0;
         [self.navigationController pushViewController:controller animated:YES];
 
         [controller setAcceptBlock:^(DZNPhotoEditorViewController *editor, NSDictionary *userInfo){
-            [metadata postMetadataUpdate:userInfo];
+            if (self.searchController.searchBar.text) {
+                NSMutableDictionary *allUserInfo = [userInfo mutableCopy];
+                if (self.searchController.searchBar.text) [allUserInfo setObject:self.searchController.searchBar.text forKey:DZNPhotoPickerControllerSearchTerm];
+                [metadata postMetadataUpdate:allUserInfo];
+            } else {
+                [metadata postMetadataUpdate:userInfo];
+            }
+            
             [self.navigationController popViewControllerAnimated:YES];
         }];
         
@@ -471,7 +478,13 @@ static NSUInteger kDZNPhotoDisplayMinimumColumnCount = 4.0;
                                                              progress:NULL
                                                             completed:^(UIImage *image, NSData *data, NSError *error, BOOL finished){
                                                                 if (image) {
-                                                                    NSDictionary *userInfo = @{UIImagePickerControllerOriginalImage: image};
+                                                                    NSMutableDictionary *userInfo = [[NSMutableDictionary alloc] init];
+                                                                    [userInfo setObject:image forKey:UIImagePickerControllerOriginalImage];
+                                                                    
+                                                                    if (self.searchController.searchBar.text) {
+                                                                        [userInfo setObject:self.searchController.searchBar.text forKey:DZNPhotoPickerControllerSearchTerm];
+                                                                    }
+                                                                    
                                                                     [metadata postMetadataUpdate:userInfo];
                                                                 }
                                                                 else {

--- a/Source/Classes/Core/DZNPhotoPickerController.m
+++ b/Source/Classes/Core/DZNPhotoPickerController.m
@@ -139,6 +139,7 @@ static DZNPhotoPickerControllerCancellationBlock _cancellationBlock;
     if (self.finalizationBlock) {
         self.finalizationBlock(self, notification.userInfo);
     }
+    
     else if (self.delegate && [self.delegate respondsToSelector:@selector(photoPickerController:didFinishPickingPhotoWithInfo:)]){
         [self.delegate photoPickerController:self didFinishPickingPhotoWithInfo:notification.userInfo];
     }

--- a/Source/Classes/Core/DZNPhotoPickerControllerConstants.h
+++ b/Source/Classes/Core/DZNPhotoPickerControllerConstants.h
@@ -11,6 +11,7 @@
 extern NSString *const DZNPhotoPickerControllerCropMode;              // An NSString (i.e. square, circular)
 extern NSString *const DZNPhotoPickerControllerCropZoomScale;         // An NSString (from 1.0 to maximum zoom scale, 2.0f)
 extern NSString *const DZNPhotoPickerControllerPhotoMetadata;         // An NSDictionary containing metadata from a captured photo
+extern NSString *const DZNPhotoPickerControllerSearchTerm;            // An NSString containing the search term that allowed the user to find this photo.
 
 extern NSString *const DZNPhotoPickerDidFinishPickingNotification;    // The notification key used when picking a photo finished.
 extern NSString *const DZNPhotoPickerDidFailPickingNotification;      // The notification key used when picking a photo failed.

--- a/Source/Classes/Core/DZNPhotoPickerControllerConstants.m
+++ b/Source/Classes/Core/DZNPhotoPickerControllerConstants.m
@@ -13,6 +13,7 @@
 NSString *const DZNPhotoPickerControllerCropMode =              @"com.dzn.photoPicker.cropMode";
 NSString *const DZNPhotoPickerControllerCropZoomScale =         @"com.dzn.photoPicker.cropZoomScale";
 NSString *const DZNPhotoPickerControllerPhotoMetadata =         @"com.dzn.photoPicker.photoMetadata";
+NSString *const DZNPhotoPickerControllerSearchTerm =            @"com.dzn.photoPicker.searchTerm";
 
 NSString *const DZNPhotoPickerDidFinishPickingNotification =    @"com.dzn.photoPicker.didFinishPickingNotification";
 NSString *const DZNPhotoPickerDidFailPickingNotification =      @"com.dzn.photoPicker.didFinishPickingWithErrorNotification";


### PR DESCRIPTION
This allows us in our use-case to make it a one-click option to search for the last search term the user searched for since we have our own custom live-preview, GPU-accelerated cropping UI and cannot use DZNPhotoPickerController's.