### PR TITLE
I wasn't able to run DZNPhotoPickerController in my project before doing this

### DIFF
--- a/Source/Classes/Services/DZNPhotoServiceClient.h
+++ b/Source/Classes/Services/DZNPhotoServiceClient.h
@@ -8,7 +8,7 @@
 //  Licence: MIT-Licence
 //
 
-#import "AFNetworking.h"
+#import <AFNetworking/AFNetworking.h>
 #import "DZNPhotoServiceClientProtocol.h"
 #import "DZNPhotoPickerControllerConstants.h"
 


### PR DESCRIPTION
I was having the issue "`*****/Pods/DZNPhotoPickerController/Source/Classes/Services/DZNPhotoServiceClient.h:11:9: Include of non-modular header inside framework module 'DZNPhotoPickerController.DZNPhotoServiceClient'`".

![issue](https://cloud.githubusercontent.com/assets/1765696/18149803/d87429a6-6fb8-11e6-9114-7d75df298f3d.png)
