### PR TITLE
Fix Xcode 8.3 warnings

### DIFF
--- a/Source/Classes/Editor/DZNPhotoEditorViewController.m
+++ b/Source/Classes/Editor/DZNPhotoEditorViewController.m
@@ -10,8 +10,8 @@
 
 #import "DZNPhotoEditorViewController.h"
 
-#define DZN_IS_IPAD [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad
-#define DZN_IS_IOS8 [[UIDevice currentDevice].systemVersion floatValue] > 8.0
+#define DZN_IS_IPAD ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad)
+#define DZN_IS_IOS8 ([[UIDevice currentDevice].systemVersion floatValue] > 8.0)
 
 typedef NS_ENUM(NSInteger, DZNPhotoAspect) {
     DZNPhotoAspectUnknown,


### PR DESCRIPTION
Fixes the issues:
```
DZNPhotoEditorViewController.m:149:9: Logical not is only applied to the left hand side of this comparison
DZNPhotoEditorViewController.m:158:9: Logical not is only applied to the left hand side of this comparison
DZNPhotoEditorViewController.m:171:9: Logical not is only applied to the left hand side of this comparison
DZNPhotoEditorViewController.m:332:24: Logical not is only applied to the left hand side of this comparison
```

cc @patniemeyer